### PR TITLE
Add component references system

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -34,3 +34,25 @@ Here, `../data/cubicparams.csv` is a parameter definition file that looks someth
 -.57211657,.17500949,-.01388863
 .04413228,-.01388863,.00111965
 ```
+
+## How do I use component references?
+
+Component references allow you to write cleaner model code when connecting components.  The `addcomponent` function returns a reference to the component that you just added:
+```
+mycomponent = addcomponent(model, MyComponent)
+```
+
+If you want to get a reference to a component after the `addcomponent` call has been made, you can construct the reference as:
+```
+mycomponent = ComponentReference(model, :MyComponent)
+```
+
+You can use this component reference in place of the `setparameter` and `connectparameter` calls.
+
+## References in place of `setparameter`
+
+The line `setparameter(model, :MyComponent, :myparameter, myvalue)` can be written as `mycomponent[:myparameter] = myvalue`, where `mycomponent` is a component reference.
+
+## References in place of `connectparameter`
+
+The line `connectparameter(model, :MyComponent, :myparameter, :YourComponent, :yourparameter)` can be written as `mycomponent[:myparameter] = yourcomponent[:yourparameter]`, where `mycomponent` and `yourcomponent` are component references.

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -200,12 +200,12 @@ function addcomponent(m::Model, t, name::Symbol;before=nothing,after=nothing)
 	else
 		m.components[name] = comp
 	end
-	nothing
+
+    ComponentReference(m, name)
 end
 
 function addcomponent(m::Model, t;before=nothing,after=nothing)
 	addcomponent(m,t,symbol(string(t)),before=before,after=after)
-	nothing
 end
 
 """
@@ -544,5 +544,7 @@ function timestep(s::adder, t::Int)
 
     v.output[t] = p.input[t] + p.add[t]
 end
+
+include("references.jl")
 
 end # module

--- a/src/references.jl
+++ b/src/references.jl
@@ -1,0 +1,62 @@
+export ComponentReference
+
+import Base.setindex!, Base.getindex
+
+"""
+A container for a component, for interacting with it within a model.
+"""
+type ComponentReference
+    m::Model
+    component::Symbol
+end
+
+"""
+Set a component parameter as `setparameter(reference, name, value)`.
+"""
+function setparameter(c::ComponentReference, name::Symbol, value)
+    setparameter(c.m, c.component, name, value)
+end
+
+"""
+Set a component parameter as `reference[symbol] = value`.
+"""
+function setindex!(c::ComponentReference, value, name::Symbol)
+    setparameter(c.m, c.component, name, value)
+end
+
+"""
+Connect two components as `connectparameter(reference1, name1, reference2, name2)`.
+"""
+function connectparameter(target::ComponentReference, target_name::Symbol, source::ComponentReference, source_name::Symbol)
+    connectparameter(target.m, target.component, target_name, source.component, source_name)
+end
+
+"""
+Connect two components as `connectparameter(reference1, reference2, name)`.
+"""
+function connectparameter(target::ComponentReference, source::ComponentReference, name::Symbol)
+    connectparameter(target.m, target.component, name, source.component, name)
+end
+
+"""
+A container for a name within a component, to improve connectparameter aesthetics.
+"""
+type VariableReference
+    m::Model
+    component::Symbol
+    name::Symbol
+end
+
+"""
+Get a variable reference as `reference[name]`.
+"""
+function getindex(c::ComponentReference, name::Symbol)
+    VariableReference(c.m, c.component, name)
+end
+
+"""
+Connect two components as `reference1[name1] = reference2[name2]`.
+"""
+function setindex!(target::ComponentReference, source::VariableReference, name::Symbol)
+    connectparameter(target.m, target.component, name, source.component, source.name)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Mimi
 using Base.Test
 
-tests = ["main"]
+tests = ["main", "references"]
 
 for t in tests
 	fp = joinpath("test_$t.jl")

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -6,7 +6,7 @@ using Mimi
 	intermed = Variable(index=[time])
 end
 
-function timestep(c::Foo, tt::Int)
+function timestep(c::Foo, tt)
     c.Variables.intermed[tt] = c.Parameters.input
 end
 
@@ -15,7 +15,7 @@ end
 	output = Variable(index=[time])
 end
 
-function timestep(c::Bar, tt::Int)
+function timestep(c::Bar, tt)
     c.Variables.output[tt] = c.Parameters.intermed[tt]
 end
 

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -24,10 +24,10 @@ setindex(m, :time, 1)
 foo = addcomponent(m, Foo)
 bar = addcomponent(m, Bar)
 
-foo[:input] = convert(Float64, π)
+foo[:input] = 3.14
 bar[:intermed] = foo[:intermed]
 
 run(m)
 
-@test m[:Bar, :output][1] == convert(Float64, π)
+@test m[:Bar, :output][1] == 3.14
 

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -1,0 +1,33 @@
+using Base.Test
+using Mimi
+
+@defcomp Foo begin
+	input = Parameter()
+	intermed = Variable(index=[time])
+end
+
+function timestep(c::Foo, tt::Int)
+    c.Variables.intermed[tt] = c.Parameters.input
+end
+
+@defcomp Bar begin
+	intermed = Parameter(index=[time])
+	output = Variable(index=[time])
+end
+
+function timestep(c::Bar, tt::Int)
+    c.Variables.output[tt] = c.Parameters.intermed[tt]
+end
+
+m = Model()
+setindex(m, :time, 1)
+foo = addcomponent(m, Foo)
+bar = addcomponent(m, Bar)
+
+foo[:input] = convert(Float64, π)
+bar[:intermed] = foo[:intermed]
+
+run(m)
+
+@test m[:Bar, :output][1] == convert(Float64, π)
+


### PR DESCRIPTION
Here is the system for component references-- so that we can write, e.g.,
connectparameter(model, :MyComponent, :myparameter, :YourComponent, :yourparameter)
as
mycomponent[:myparameter] = yourcomponent[:yourparameter]