### PR TITLE
Move type creation from macro to normal runtime phase

### DIFF
--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -382,13 +382,6 @@ end
 Define a new component.
 """
 macro defcomp(name, ex)
-    dimdef = Expr(:block)
-    dimconstructor = Expr(:block)
-
-    pardef = Expr(:block)
-
-    vardef = Expr(:block)
-    varalloc = Expr(:block)
     resetvarsdef = Expr(:block)
 
     metavardef = Expr(:block)
@@ -398,9 +391,6 @@ macro defcomp(name, ex)
     for line in ex.args
         if line.head==:(=) && line.args[2].head==:call && line.args[2].args[1]==:Index
             dimensionName = line.args[1]
-
-            push!(dimdef.args,:($(esc(dimensionName))::$(esc(UnitRange{Int64}))))
-            push!(dimconstructor.args,:(s.$(dimensionName) = UnitRange{Int64}(1,indices[$(QuoteNode(dimensionName))])))
 
             push!(metadimdef.args, :(metainfo.adddimension(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(dimensionName)) )))
         elseif line.head==:(=) && line.args[2].head==:call && line.args[2].args[1]==:Parameter
@@ -414,33 +404,18 @@ macro defcomp(name, ex)
                 error()
             end
 
-            concreteParameterType = parameterType == :Number ? :T : parameterType
-
             if any(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)
                 parameterIndex = first(filter(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)).args[2].args
-                partypedef = :(Array{$(concreteParameterType),$(length(parameterIndex))})
 
                 pardims = Array(Any, 0)
-                u = :(temp_indices = [])
                 for l in parameterIndex
-                    if isa(l, Symbol)
-                        push!(u.args[2].args, :(indices[$(QuoteNode(l))]))
-                    elseif isa(l, Int)
-                        push!(u.args[2].args, l)
-                    else
-                        error()
-                    end
                     push!(pardims, l)
                 end
 
                 push!(metapardef.args, :(metainfo.addparameter(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(parameterName)), $(esc(parameterType)), $(pardims), "", "")))
             else
-                partypedef = concreteParameterType
-
                 push!(metapardef.args, :(metainfo.addparameter(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(parameterName)), $(esc(parameterType)), [], "", "")))
             end
-
-            push!(pardef.args,:($(esc(parameterName))::$(esc(partypedef))))
         elseif line.head==:(=) && line.args[2].head==:call && line.args[2].args[1]==:Variable
             if isa(line.args[1], Symbol)
                 variableName = line.args[1]
@@ -452,43 +427,25 @@ macro defcomp(name, ex)
                 error()
             end
 
-            concreteVariableType = variableType == :Number ? :T : variableType
-
             if any(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)
                 variableIndex = first(filter(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)).args[2].args
-                vartypedef = :(Array{$(concreteVariableType),$(length(variableIndex))})
 
                 vardims = Array(Any, 0)
-                u = :(temp_indices = [])
                 for l in variableIndex
-                    if isa(l, Symbol)
-                        push!(u.args[2].args, :(indices[$(QuoteNode(l))]))
-                    elseif isa(l, Int)
-                        push!(u.args[2].args, l)
-                    else
-                        error()
-                    end
                     push!(vardims, l)
                 end
                 push!(metavardef.args, :(metainfo.addvariable(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(variableName)), $(esc(variableType)), $(vardims), "", "")))
-
-                push!(varalloc.args,u)
-                push!(varalloc.args,:(s.$(variableName) = Array($(concreteVariableType),temp_indices...)))
 
                 if variableType==:Number
                     push!(resetvarsdef.args,:($(esc(symbol("fill!")))(s.Variables.$(variableName),$(esc(symbol("NaN"))))))
                 end
             else
-                vartypedef = concreteVariableType
                 push!(metavardef.args, :(metainfo.addvariable(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(variableName)), $(esc(variableType)), [], "", "")))
 
                 if variableType==:Number
                     push!(resetvarsdef.args,:(s.Variables.$(variableName) = $(esc(symbol("NaN")))))
                 end
             end
-
-            push!(vardef.args,:($(esc(variableName))::$(esc(vartypedef))))
-
         elseif line.head==:line
         else
             error("Unknown expression.")

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -393,6 +393,7 @@ macro defcomp(name, ex)
 
     metavardef = Expr(:block)
     metapardef = Expr(:block)
+    metadimdef = Expr(:block)
 
     for line in ex.args
         if line.head==:(=) && line.args[2].head==:call && line.args[2].args[1]==:Index
@@ -400,6 +401,8 @@ macro defcomp(name, ex)
 
             push!(dimdef.args,:($(esc(dimensionName))::$(esc(UnitRange{Int64}))))
             push!(dimconstructor.args,:(s.$(dimensionName) = UnitRange{Int64}(1,indices[$(QuoteNode(dimensionName))])))
+
+            push!(metadimdef.args, :(metainfo.adddimension(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(dimensionName)) )))
         elseif line.head==:(=) && line.args[2].head==:call && line.args[2].args[1]==:Parameter
             if isa(line.args[1], Symbol)
                 parameterName = line.args[1]
@@ -492,64 +495,20 @@ macro defcomp(name, ex)
         end
     end
 
+    module_def = :(eval(current_module(), :(module temporary_name end)))
+    module_def.args[3].args[1].args[2] = symbol(string("_mimi_implementation_", name))
+
+    call_expr = Expr(:call,
+        Expr(:curly,
+            Expr(:., Expr(:., symbol(current_module()), QuoteNode(symbol(string("_mimi_implementation_", name)))), QuoteNode(symbol(string(name,"Impl")))) ,
+            :T),
+        :T,
+        :indices
+        )
+
     x = quote
 
-        type $(symbol(string(name,"Parameters"))){$(esc(:T))}
-            $(pardef)
-
-            function $(esc(symbol(string(name,"Parameters")))){$(esc(:T))}(::Type{$(esc(:T))})
-                $(esc(:s)) = new{$(esc(:T))}()
-                return $(esc(:s))
-            end
-        end
-
-        type $(symbol(string(name,"Variables"))){$(esc(:T))}
-            $(vardef)
-
-            function $(esc(symbol(string(name, "Variables")))){$(esc(:T))}(::Type{$(esc(:T))}, indices)
-                $(esc(:indices)) = indices
-                $(esc(:s)) = new{$(esc(:T))}()
-                $(esc(varalloc))
-                return $(esc(:s))
-            end
-        end
-
-        type $(symbol(string(name,"Dimensions")))
-            $(dimdef)
-
-            function $(esc(symbol(string(name,"Dimensions"))))(indices)
-                $(esc(:indices)) = indices
-                $(esc(:s)) = new()
-                $(esc(dimconstructor))
-                return $(esc(:s))
-            end
-        end
-
         abstract $(esc(symbol(name))) <: Mimi.ComponentState
-
-        type $(esc(symbol(string(name, "Impl")))){T} <: $(esc(symbol(name)))
-            nsteps::Int
-            Parameters::$(esc(symbol(string(name,"Parameters")))){T}
-            Variables::$(esc(symbol(string(name,"Variables")))){T}
-            Dimensions::$(esc(symbol(string(name,"Dimensions"))))
-
-            function $(esc(symbol(string(name, "Impl")))){T}(::Type{T}, indices)
-                s = new{T}()
-                s.nsteps = indices[:time]
-                s.Parameters = $(esc(symbol(string(name,"Parameters")))){T}(T)
-                s.Dimensions = $(esc(symbol(string(name,"Dimensions"))))(indices)
-                s.Variables = $(esc(symbol(string(name,"Variables")))){T}(T, indices)
-                return s
-            end
-        end
-
-        function $(esc(symbol(name)))(indices)
-            return $(esc(symbol(string(name, "Impl")))){Float64}(Float64, indices)
-        end
-
-        function $(esc(symbol(name))){T}(::Type{T}, indices)
-            return $(esc(symbol(string(name, "Impl")))){T}(T, indices)
-        end
 
         import Mimi.timestep
         import Mimi.init
@@ -562,6 +521,16 @@ macro defcomp(name, ex)
         metainfo.addcomponent(module_name(current_module()), $(Expr(:quote,name)))
         $(metavardef)
         $(metapardef)
+        $(metadimdef)
+
+        $(module_def)
+
+        eval($(esc(symbol(string("_mimi_implementation_", name)))), metainfo.generate_comp_expressions(module_name(current_module()), $(Expr(:quote,name))))
+
+        function $(esc(symbol(name))){T}(::Type{T}, indices)
+            $(call_expr)
+        end
+
     end
 
     x

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -457,7 +457,7 @@ macro defcomp(name, ex)
 
     call_expr = Expr(:call,
         Expr(:curly,
-            Expr(:., Expr(:., symbol(current_module()), QuoteNode(symbol(string("_mimi_implementation_", name)))), QuoteNode(symbol(string(name,"Impl")))) ,
+            Expr(:., Expr(:., Expr(:., :Main, QuoteNode(symbol(current_module()))), QuoteNode(symbol(string("_mimi_implementation_", name)))), QuoteNode(symbol(string(name,"Impl")))) ,
             :T),
         :T,
         :indices

--- a/src/metainfo.jl
+++ b/src/metainfo.jl
@@ -16,15 +16,20 @@ type MetaParameter
     unit::UTF8String
 end
 
+type MetaDimension
+    name::Symbol
+end
+
 type MetaComponent
     module_name::Symbol
     component_name::Symbol
 
     variables::Dict{Symbol,MetaVariable}
     parameters::Dict{Symbol,MetaParameter}
+    dimensions::Dict{Symbol,MetaDimension}
 
     function MetaComponent(module_name::Symbol, component_name::Symbol)
-        v = new(module_name, component_name, Dict{Symbol, MetaVariable}(), Dict{Symbol, MetaVariable}())
+        v = new(module_name, component_name, Dict{Symbol, MetaVariable}(), Dict{Symbol, MetaParameter}(), Dict{Symbol, MetaDimension}())
         return v
     end
 end
@@ -53,8 +58,134 @@ function addparameter(module_name::Symbol, component_name::Symbol, name, datatyp
     nothing
 end
 
+function adddimension(module_name::Symbol, component_name::Symbol, name)
+    c = _mimi_metainfo[(module_name, component_name)]
+
+    d = MetaDimension(name)
+    c.dimensions[name] = d
+    nothing
+end
+
+
 function getallcomps()
     _mimi_metainfo
+end
+
+function generate_comp_expressions(module_name, component_name)
+    parameters = values(_mimi_metainfo[(module_name, component_name)].parameters)
+    variables = values(_mimi_metainfo[(module_name, component_name)].variables)
+    dimensions = values(_mimi_metainfo[(module_name, component_name)].dimensions)
+    quote
+        using Mimi
+
+        # Define type for parameters
+        type $(symbol(string(component_name,"Parameters"))){T}
+            $(begin
+                x = Expr(:block)
+                for p in parameters
+                    concreteParameterType = p.datatype == Number ? :T : p.datatype
+
+                    if length(p.dimensions)==0
+                        push!(x.args, :($(p.name)::$(concreteParameterType)) )
+                    else
+                        push!(x.args, :($(p.name)::Array{$(concreteParameterType),$(length(p.dimensions))}) )
+                    end
+                end
+                x
+            end)
+
+            function $(symbol(string(component_name,"Parameters"))){T}(::Type{T})
+                new{T}()
+            end
+        end
+
+        # Define type for variables
+        type $(symbol(string(component_name,"Variables"))){T}
+            $(begin
+                x = Expr(:block)
+                for v in variables
+                    concreteVariableType = v.datatype == Number ? :T : v.datatype
+
+                    if length(v.dimensions)==0
+                        push!(x.args, :($(v.name)::$(concreteVariableType)) )
+                    else
+                        push!(x.args, :($(v.name)::Array{$(concreteVariableType),$(length(v.dimensions))}) )
+                    end
+                end
+                x
+            end)
+
+            function $(symbol(string(component_name, "Variables"))){T}(::Type{T}, indices)
+                s = new{T}()
+
+                $(begin
+                    ep = Expr(:block)
+                    for v in filter(i->length(i.dimensions)>0, variables)
+                        concreteVariableType = v.datatype == Number ? :T : v.datatype
+
+                        u = :(temp_indices = [])
+                        for l in v.dimensions
+                            if isa(l, Symbol)
+                                push!(u.args[2].args, :(indices[$(QuoteNode(l))]))
+                            elseif isa(l, Int)
+                                push!(u.args[2].args, l)
+                            else
+                                error()
+                            end
+                        end
+                        push!(ep.args,u)
+                        push!(ep.args,:(s.$(v.name) = Array($(concreteVariableType),temp_indices...)))
+                    end
+                    ep
+                end)
+
+                return s
+            end
+        end
+
+
+        # Define type for dimensions
+        type $(symbol(string(component_name,"Dimensions")))
+            $(begin
+                x = Expr(:block)
+                for d in dimensions
+                    push!(x.args, :($(d.name)::UnitRange{Int64}) )
+                end
+                x
+            end)
+
+            function $(symbol(string(component_name,"Dimensions")))(indices)
+                s = new()
+                $(begin
+                    ep = Expr(:block)
+                    for d in dimensions
+                        push!(ep.args,:(s.$(d.name) = UnitRange{Int64}(1,indices[$(QuoteNode(d.name))])))
+                    end
+                    ep
+                end)
+                return s
+            end
+        end
+
+        # Define implementation typeof
+        type $(symbol(string(component_name, "Impl"))){T} <: $(symbol(module_name)).$(symbol(component_name))
+            nsteps::Int
+            Parameters::$(symbol(string(component_name,"Parameters"))){T}
+            Variables::$(symbol(string(component_name,"Variables"))){T}
+            Dimensions::$(symbol(string(component_name,"Dimensions")))
+
+            function $(symbol(string(component_name, "Impl"))){T}(::Type{T}, indices)
+                s = new{T}()
+                s.nsteps = indices[:time]
+                s.Parameters = $(symbol(string(component_name,"Parameters"))){T}(T)
+                s.Dimensions = $(symbol(string(component_name,"Dimensions")))(indices)
+                s.Variables = $(symbol(string(component_name,"Variables"))){T}(T, indices)
+                return s
+            end
+        end
+
+
+    end
 end
 
 end

--- a/src/metainfo.jl
+++ b/src/metainfo.jl
@@ -168,7 +168,7 @@ function generate_comp_expressions(module_name, component_name)
         end
 
         # Define implementation typeof
-        type $(symbol(string(component_name, "Impl"))){T} <: $(symbol(module_name)).$(symbol(component_name))
+        type $(symbol(string(component_name, "Impl"))){T} <: Main.$(symbol(module_name)).$(symbol(component_name))
             nsteps::Int
             Parameters::$(symbol(string(component_name,"Parameters"))){T}
             Variables::$(symbol(string(component_name,"Variables"))){T}

--- a/test/test_main.jl
+++ b/test/test_main.jl
@@ -16,7 +16,7 @@ using DataFrames
     var5 = Variable(index=[index1,4])
 end
 
-x1 = foo1(Dict{Symbol, Int}(:time=>10, :index1=>3))
+x1 = foo1(Float64, Dict{Symbol, Int}(:time=>10, :index1=>3))
 
 @test x1.Dimensions.index1.start == 1
 @test x1.Dimensions.index1.stop == 3


### PR DESCRIPTION
@jrising and @FrankErrickson: This changes some fundamental things under the hood, but should not break any existing code that uses Mimi. I tried it with fund.jl, mimi-sneasy.jl, mimi-dice-2013.jl and mimi-rice-2010.jl and those all seem to work. I believe you both have code basis that use Mimi that I don't have access to, could you try to run those with the version of Mimi in this PR and let me know if there are any problems?

The major benefit for now is that one can redefine a component with this version without exiting the julia process. More medium/longterm this PR lays the foundation for a whole bunch of other improvements. Plus the code should be a fair bit easier to maintain because now less stuff is happening in the macro itself, which always was a pain to develop/debug.

Thanks!