### PR TITLE
add unit handling and connection checking

### DIFF
--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -8,7 +8,7 @@ using Distributions
 export
     ComponentState, timestep, run, @defcomp, Model, setindex, addcomponent, setparameter,
     connectparameter, setleftoverparameters, getvariable, adder, MarginalModel, getindex,
-    getdataframe, components, variables, setbestguess, setrandom, getvpd
+    getdataframe, components, variables, setbestguess, setrandom, getvpd, unitcheck
 
 import
     Base.getindex, Base.run
@@ -156,13 +156,20 @@ function components(m::Model)
 end
 
 """
-List all the variables in a component.
+Return the MetaComponent for a given component
 """
-function variables(m::Model, componentname::Symbol)
+function getmetainfo(m::Model, componentname::Symbol)
     meta = metainfo.getallcomps()
     meta_module_name = symbol(super(typeof(m.components[componentname])).name.module)
     meta_component_name = symbol(super(typeof(m.components[componentname])).name.name)
-    c = meta[(meta_module_name, meta_component_name)]
+    meta[(meta_module_name, meta_component_name)]
+end
+
+"""
+List all the variables in a component.
+"""
+function variables(m::Model, componentname::Symbol)
+    c = getmetainfo(m, componentname)
     collect(keys(c.variables))
 end
 
@@ -271,9 +278,22 @@ end
 function connectparameter(m::Model, target_component::Symbol, target_name::Symbol, source_component::Symbol, source_name::Symbol)
     c_target = m.components[target_component]
     c_source = m.components[source_component]
+
+    # Check the units, if provided
+    @assert unitcheck(getmetainfo(m, target_component).parameters[target_name].unit,
+                      getmetainfo(m, source_component).variables[source_name].unit) "Units of $source_component.$source_name do not match $target_component.$target_name."
+
     setfield!(c_target.Parameters, target_name, getfield(c_source.Variables, source_name))
     push!(m.parameters_that_are_set, string(target_component) * string(target_name))
     nothing
+end
+
+"""
+Default string, string unit check function
+"""
+function unitcheck(one::Union{UTF8String, ASCIIString}, two::Union{UTF8String, ASCIIString})
+    # True if both "", either are "any", or they match
+    return one == "any" || two == "any" || one == two
 end
 
 """
@@ -379,6 +399,20 @@ function getvpd(s)
 end
 
 """
+Helper function for macro: collects all the keyword arguments in a function call to a dictionary.
+"""
+function collectkw(args::Vector{Any})
+    kws = Dict{Symbol, Any}()
+    for arg in args
+        if isa(arg, Expr) && arg.head == :kw
+            kws[arg.args[1]] = arg.args[2]
+        end
+    end
+
+    kws
+end
+
+"""
 Define a new component.
 """
 macro defcomp(name, ex)
@@ -404,17 +438,23 @@ macro defcomp(name, ex)
                 error()
             end
 
-            if any(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)
-                parameterIndex = first(filter(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)).args[2].args
+            kws = collectkw(line.args[2].args)
+
+            # Get description and units, if provided
+            description = get(kws, :description, "") # Proposal: change to 'nothing'
+            units = get(kws, :units, "") # Proposal: change to 'nothing'
+
+            if haskey(kws, :index)
+                parameterIndex = kws[:index].args
 
                 pardims = Array(Any, 0)
                 for l in parameterIndex
                     push!(pardims, l)
                 end
 
-                push!(metapardef.args, :(metainfo.addparameter(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(parameterName)), $(esc(parameterType)), $(pardims), "", "")))
+                push!(metapardef.args, :(metainfo.addparameter(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(parameterName)), $(esc(parameterType)), $(pardims), $(description), $(units))))
             else
-                push!(metapardef.args, :(metainfo.addparameter(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(parameterName)), $(esc(parameterType)), [], "", "")))
+                push!(metapardef.args, :(metainfo.addparameter(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(parameterName)), $(esc(parameterType)), [], $(description), $(units))))
             end
         elseif line.head==:(=) && line.args[2].head==:call && line.args[2].args[1]==:Variable
             if isa(line.args[1], Symbol)
@@ -427,20 +467,27 @@ macro defcomp(name, ex)
                 error()
             end
 
-            if any(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)
-                variableIndex = first(filter(l->isa(l,Expr) && l.head==:kw && l.args[1]==:index,line.args[2].args)).args[2].args
+            kws = collectkw(line.args[2].args)
+
+            # Get description and units, if provided
+            description = get(kws, :description, "") # Proposal: change to 'nothing'
+            units = get(kws, :units, "") # Proposal: change to 'nothing'
+
+            if haskey(kws, :index)
+                variableIndex = kws[:index].args
 
                 vardims = Array(Any, 0)
                 for l in variableIndex
                     push!(vardims, l)
                 end
-                push!(metavardef.args, :(metainfo.addvariable(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(variableName)), $(esc(variableType)), $(vardims), "", "")))
+
+                push!(metavardef.args, :(metainfo.addvariable(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(variableName)), $(esc(variableType)), $(vardims), $(description), $(units))))
 
                 if variableType==:Number
                     push!(resetvarsdef.args,:($(esc(symbol("fill!")))(s.Variables.$(variableName),$(esc(symbol("NaN"))))))
                 end
             else
-                push!(metavardef.args, :(metainfo.addvariable(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(variableName)), $(esc(variableType)), [], "", "")))
+                push!(metavardef.args, :(metainfo.addvariable(module_name(current_module()), $(Expr(:quote,name)), $(QuoteNode(variableName)), $(esc(variableType)), [], $(description), $(units))))
 
                 if variableType==:Number
                     push!(resetvarsdef.args,:(s.Variables.$(variableName) = $(esc(symbol("NaN")))))

--- a/src/metainfo.jl
+++ b/src/metainfo.jl
@@ -5,7 +5,7 @@ type MetaVariable
     datatype::DataType
     dimensions::Array{Any}
     description::UTF8String
-    unit::UTF8String
+    unit::Any
 end
 
 type MetaParameter
@@ -13,7 +13,7 @@ type MetaParameter
     datatype::DataType
     dimensions::Array{Any}
     description::UTF8String
-    unit::UTF8String
+    unit::Any
 end
 
 type MetaDimension

--- a/src/metainfo.jl
+++ b/src/metainfo.jl
@@ -5,7 +5,7 @@ type MetaVariable
     datatype::DataType
     dimensions::Array{Any}
     description::UTF8String
-    unit::Any
+    unit::UTF8String
 end
 
 type MetaParameter
@@ -13,7 +13,7 @@ type MetaParameter
     datatype::DataType
     dimensions::Array{Any}
     description::UTF8String
-    unit::Any
+    unit::UTF8String
 end
 
 type MetaDimension

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Mimi
 using Base.Test
 
-tests = ["main", "references"]
+tests = ["main", "references", "units"]
 
 for t in tests
     fp = joinpath("test_$t.jl")

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -1,21 +1,22 @@
 using Base.Test
 using Mimi
 
-@test unitcheck("kg", "any")
+# Try directly using unitcheck
 @test unitcheck("kg", "kg")
 @test !unitcheck("kg", "MT")
+@test !unitcheck("kg", "")
 
-
+# Create a model with some matching and some mis-matching units
 @defcomp FooUnits begin
-    output = Variable(units="kg")
+    output = Variable(unit="kg")
 end
 
 @defcomp BarUnits begin
-    input = Parameter(units="MT")
+    input = Parameter(unit="MT")
 end
 
 @defcomp BazUnits begin
-    input = Parameter(units="kg")
+    input = Parameter(unit="kg")
 end
 
 m = Model()
@@ -24,6 +25,10 @@ foo = addcomponent(m, FooUnits)
 bar = addcomponent(m, BarUnits)
 baz = addcomponent(m, BazUnits)
 
-@test_throws AssertionError bar[:input] = foo[:output]
+# Check that we cannot connect foo and bar...
+@test_throws ErrorException bar[:input] = foo[:output]
+# ...unless we pass ignoreunits=true
+connectparameter(m, :BarUnits, :input,  :FooUnits, :output, ignoreunits=true)
+# But we can connect foo and baz
 baz[:input] = foo[:output]
 

--- a/test/test_units.jl
+++ b/test/test_units.jl
@@ -1,0 +1,29 @@
+using Base.Test
+using Mimi
+
+@test unitcheck("kg", "any")
+@test unitcheck("kg", "kg")
+@test !unitcheck("kg", "MT")
+
+
+@defcomp FooUnits begin
+    output = Variable(units="kg")
+end
+
+@defcomp BarUnits begin
+    input = Parameter(units="MT")
+end
+
+@defcomp BazUnits begin
+    input = Parameter(units="kg")
+end
+
+m = Model()
+setindex(m, :time, 1)
+foo = addcomponent(m, FooUnits)
+bar = addcomponent(m, BarUnits)
+baz = addcomponent(m, BazUnits)
+
+@test_throws AssertionError bar[:input] = foo[:output]
+baz[:input] = foo[:output]
+


### PR DESCRIPTION
This is the component-to-component part of the unit checking system.  You add new units like this:

```waterdemand = Parameter(index=[regions, time], units="1000 m^3")```

and when you call `connectparameter` with two components, it checks that the units match, allowing a special `any` unit that matches anything, but otherwise requiring that the units are the same or both missing.  I have all my calls like this through lines like:

```allocation[:waterdemand] = waterdemand[:totaldemand]```

This does not (1) handle any unit checking anywhere except for through `connectparameter` (and not the version of `connectparameter` that takes an already-added parameter as an argument, (2) have any logic for the `UnitedObject` that I mentioned before, nor (3) apply the unit logic to equations.