### PR TITLE
Add clock type and use in run method

### DIFF
--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -1,6 +1,7 @@
 module Mimi
 
 include("metainfo.jl")
+include("clock.jl")
 using DataStructures
 using DataFrames
 using Distributions
@@ -343,16 +344,18 @@ show(io::IO, a::ComponentState) = print(io, "ComponentState")
 Run the model once.
 """
 function run(m::Model;ntimesteps=typemax(Int64))
+    clock = Clock(1,min(m.indices_counts[:time],ntimesteps))
 
     for c in values(m.components)
         resetvariables(c)
         init(c)
     end
 
-    for t=1:min(m.indices_counts[:time],ntimesteps)
+    while !finished(clock)
         for c in values(m.components)
-            timestep(c,t)
+            timestep(c,clock.t)
         end
+        move_forward(clock)
     end
 end
 

--- a/src/clock.jl
+++ b/src/clock.jl
@@ -1,0 +1,21 @@
+type Clock
+	t::Int64
+	final_t::Int64
+end
+
+function gettimestep(c::Clock)
+	return c.t
+end
+
+function move_forward(c::Clock)
+	c.t = c.t + 1
+	nothing
+end
+
+function finished(c::Clock)
+	if c.t>c.final_t
+		return true
+	else
+		return false
+	end
+end


### PR DESCRIPTION
This is in preparation for a more general API overhaul. For now this should all be considered internal.

Eventually I want to pass a ``Clock`` object to the ``timestep`` function, and then components should use ``gettimestep`` to extract the current t at the top of their ``timestep`` function. Major benefit of such a design would be that we could later add bells and whistles to the ``Clock`` object without breaking the call signature for ``timestep``, i.e. we could add features without breaking old components.

@jrising could you briefly make sure this doesn't break any of your use cases? Right now this should be entirely non-breaking.