### PR TITLE
Rename timestep to run and pass Clock instead of timestep

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Mimi.jl v.next Release Notes
 * Move type generation from macro to runtime phase (low level dev feature)
+* Rename the timestep function to run_timestep
 
 # Mimi.jl v0.0.3 Release Notes
 * Drop julia 0.3 support

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -6,7 +6,7 @@ In this example, we will construct a stylized model of the global economy and it
 There are two main steps to creating a component:
 
 * Define the component using ``@defcomp`` where the parameters and variables are listed.
-* Use the timestep function ``timestep(state::component_name, t:Int)`` to set the equations of that component.
+* Use the run_timestep function ``run_timestep(state::component_name, t::Int)`` to set the equations of that component.
 
 Starting with the economy component, each variable and parameter is listed. If either varialbes or parameters have a time-dimension, that must be set with ``(index=[time])``.
 
@@ -25,10 +25,10 @@ using Mimi
 end
 ```
 
-Next, the timestep function must be defined along with the various equations of the ``grosseconomy`` component. In this step, the variables and parameters are linked to this component by ``state`` and must be identified as either a variable or a parameter in each equation. For this example, ``v`` will refer to variables while ``p`` refers to paremeters.
+Next, the run_timestep function must be defined along with the various equations of the ``grosseconomy`` component. In this step, the variables and parameters are linked to this component by ``state`` and must be identified as either a variable or a parameter in each equation. For this example, ``v`` will refer to variables while ``p`` refers to paremeters.
 
 ```julia
-function timestep(state::grosseconomy, t::Int)
+function run_timestep(state::grosseconomy, t::Int)
 	v = state.Variables
 	p = state.Parameters
 
@@ -55,7 +55,7 @@ end
 ```
 
 ```julia
-function timestep(state::emissions, t::Int)
+function run_timestep(state::emissions, t::Int)
 	v = state.Variables
 	p = state.Parameters
 
@@ -104,7 +104,7 @@ my_model[:emissions, :E]
 We can now modify our two-component model of the globe to include multiple regional economies.  Global greenhouse gas emissions will now be the sum of regional emissions. The modeling approach is the same, with a few minor adjustments:
 
 * When using ``@defcomp``, a regions index must be specified. In addition, for variables that have a regional index it is necessary to include ``(index=[regions])``. This can be combined with the time index as well, ``(index=[time, regions])``.
-* In the timestep function, a region dimension must be defined using ``state.Dimensions``.  Unlike the time dimension, regions must be specified and looped through in any equations that contain a regional variable or parameter.
+* In the run_timestep function, a region dimension must be defined using ``state.Dimensions``.  Unlike the time dimension, regions must be specified and looped through in any equations that contain a regional variable or parameter.
 * ``setindex`` must be used to specify your regions in the same way that it is used to specify your timestep.
 * When using ``setparameter`` for values with a time and regional dimension, an array is used.  Each row corresponds to a time step, while each column corresponds to a separate region. For regional values with no timestep, a vector can be used. It is often easier to create an array of parameter values before model construction. This way, the parameter name can be entered into ``setparameter`` rather than an entire equation.
 * When constructing regionalized models with multiple components, it is often easier to save each component as a separate file and to then write a function that constructs the model.  When this is done, ``using Mimi`` must be speficied for each component. This approach will be used here.
@@ -128,7 +128,7 @@ using Mimi
 end
 
 
-function timestep(state::grosseconomy, t::Int)
+function run_timestep(state::grosseconomy, t::Int)
 	v = state.Variables
 	p = state.Parameters
 	d = state.Dimensions 						#Note that the regional dimension is defined here and parameters and variables are indexed by 'r'
@@ -164,7 +164,7 @@ using Mimi											#Make sure to call Mimi again
 end
 
 
-function timestep(state::emissions, t::Int)
+function run_timestep(state::emissions, t::Int)
 	v = state.Variables
 	p = state.Parameters
 	d = state.Dimensions

--- a/examples/01-onecomponent.jl
+++ b/examples/01-onecomponent.jl
@@ -10,9 +10,9 @@ using Mimi
 
 end
 
-# Second, define the timestep function for the component
+# Second, define the run_timestep function for the component
 
-function timestep(s::component1, t::Int)
+function run_timestep(s::component1, t::Int)
 end
 
 # Create a model uses the component

--- a/src/Mimi.jl
+++ b/src/Mimi.jl
@@ -7,7 +7,7 @@ using DataFrames
 using Distributions
 
 export
-    ComponentState, timestep, run, @defcomp, Model, setindex, addcomponent, setparameter,
+    ComponentState, run_timestep, run, @defcomp, Model, setindex, addcomponent, setparameter,
     connectparameter, setleftoverparameters, getvariable, adder, MarginalModel, getindex,
     getdataframe, components, variables, setbestguess, setrandom, getvpd, unitcheck
 
@@ -376,15 +376,15 @@ function run(m::Model;ntimesteps=typemax(Int64))
 
     while !finished(clock)
         for c in values(m.components)
-            timestep(c,clock.t)
+            run_timestep(c,clock.t)
         end
         move_forward(clock)
     end
 end
 
-function timestep(s, t)
+function run_timestep(s, t)
     typeofs = typeof(s)
-    println("Generic timestep called for $typeofs.")
+    println("Generic run_timestep called for $typeofs.")
 end
 
 function init(s)
@@ -520,7 +520,7 @@ macro defcomp(name, ex)
 
         abstract $(esc(symbol(name))) <: Mimi.ComponentState
 
-        import Mimi.timestep
+        import Mimi.run_timestep
         import Mimi.init
         import Mimi.resetvariables
 
@@ -552,7 +552,7 @@ end
     output = Variable(index=[time])
 end
 
-function timestep(s::adder, t::Int)
+function run_timestep(s::adder, t::Int)
     v = s.Variables
     p = s.Parameters
 

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -6,7 +6,7 @@ using Mimi
     intermed = Variable(index=[time])
 end
 
-function timestep(c::Foo, tt)
+function run_timestep(c::Foo, tt)
     c.Variables.intermed[tt] = c.Parameters.input
 end
 
@@ -15,7 +15,7 @@ end
     output = Variable(index=[time])
 end
 
-function timestep(c::Bar, tt)
+function run_timestep(c::Bar, tt)
     c.Variables.output[tt] = c.Parameters.intermed[tt]
 end
 


### PR DESCRIPTION
This is breaking change. There are two specific changes: 1) the ``timestep`` function is renamed to ``run`` and 2) instead of passing the time index, I now pass a ``Clock`` instance from which one can extract the current timestep via the ``gettimestep`` function.

Motivation for 1) is that it always bugged me that the function name wasn't a verb. Plus, if we ever change it then now, while we still roughly know who is using this. If you don't like the name, speak now or never ;)

Motivation for 2) is that we can later on pass more information into components without a need to update the call signature again by adding more fields to the ``Clock`` structure.

@jrising, @frankerrickson, any review would be appreciated! I plan to merge this maybe end of the week if I don't hear back. Right now I think there might be one more breaking change in how I handle external parameters, and then I hope to release a v1.0, after which backwards compatibility will be high on the list when we improve Mimi.